### PR TITLE
feat: allow overriding docs path to facilitate dev

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          path: "./docs",
+          path: process.env.DOCS_PATH || "./docs",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: `${vars.repository.href}/blob/main/docs`,
 


### PR DESCRIPTION
This will allow us to clone the website source in the main repo and work on the documentation with a live website.

A future PR will add some tooling in the main repo to set this up.